### PR TITLE
Unit test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+*.swp
+.coverage
+code_coverage/*
+html_report/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.swp
+*.runfile
 .coverage
 code_coverage/*
 html_report/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+PYTHON_FILES:= $(wildcard fluids/*.py)
+
+COVERAGE:= coverage
+
+path_to_pymodule = $(subst /,.,$(basename $(1)))
+
+unittests: clean run html annotate
+
+run: $(PYTHON_FILES)
+	@for f in $^; do \
+		echo "$(COVERAGE) run -a --include="fluids/*" $$f"; \
+		$(COVERAGE) run -a --include="fluids/*" $$f; \
+	done
+
+HTML_DIR:= html_report
+
+html: $(HTML_DIR) run
+	$(COVERAGE) html -d $<
+
+ANNOTATED_DIR:= code_coverage
+ANNOTATED_FILES:= $(foreach file,$(PYTHON_FILES),$(ANNOTATED_DIR)/$(file),cover)
+
+annotate: $(ANNOTATED_FILES)
+
+$(ANNOTATED_DIR)/%,cover: $(ANNOTATED_DIR) %
+	$(COVERAGE) annotate -d $< $(word 2,$^)
+
+clean:
+	$(COVERAGE) erase
+	rm -rf $(HTML_DIR)
+	rm -rf $(ANNOTATED_DIR)
+
+$(ANNOTATED_DIR) $(HTML_DIR):
+	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@ path_to_pymodule = $(subst /,.,$(basename $(1)))
 
 unittests: clean run html annotate
 
-run: $(PYTHON_FILES)
-	@for f in $^; do \
-		echo "$(COVERAGE) run -a --include="fluids/*" $$f"; \
-		$(COVERAGE) run -a --include="fluids/*" $$f; \
-	done
+RUN_SUFFIX:= runfile
+RUN_FILES:= $(addsuffix .$(RUN_SUFFIX),$(PYTHON_FILES))
+
+run: $(RUN_FILES)
+
+%.$(RUN_SUFFIX): %
+	$(COVERAGE) run -m -a --include="fluids/*" $(call path_to_pymodule,$<)
+	@touch $@
 
 HTML_DIR:= html_report
 
@@ -29,6 +32,7 @@ clean:
 	$(COVERAGE) erase
 	rm -rf $(HTML_DIR)
 	rm -rf $(ANNOTATED_DIR)
+	rm -rf $$(find . -name "*.$(RUN_SUFFIX)" -type f)
 
 $(ANNOTATED_DIR) $(HTML_DIR):
 	mkdir -p $@

--- a/fluids/safety_valve.py
+++ b/fluids/safety_valve.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.'''
 from __future__ import division
 from math import exp
 from scipy.constants import psi, F2K, inch, atm, C2K
-from fluids.compressible import is_critical_flow
+from .compressible import is_critical_flow
 from scipy.interpolate import interp1d, interp2d
 
 __all__ = ['API526_A_sq_inch', 'API526_letters', 'API526_A',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-numpy
-scipy
+argparse==1.2.1
+coverage==4.0.3
+numpy==1.10.4
+scipy==0.17.0
+wsgiref==0.1.2


### PR DESCRIPTION
Added unit test coverage:

    * View code coverage by opening html_report/index.html
    * View which lines were covered in code_coverage/ folder

Changed fluids/safety_valve.py to use `from .compressible` instead of `from fluids.compressible` which is more common and makes it so that the user does not have to have fluids in their python path

Added a Makefile to automate testing and code coverage

Added .gitignore to ignore:

    * Compiled python files
    * Vim swap files
    * Code Coverage files