### PR TITLE
Misc. typo fixes

### DIFF
--- a/docs/Examples/Crane TP 410 Solved Problems/7.1 Smooth Pipe (Plastic).ipynb
+++ b/docs/Examples/Crane TP 410 Solved Problems/7.1 Smooth Pipe (Plastic).ipynb
@@ -13,7 +13,7 @@
     "collapsed": false
    },
    "source": [
-    "Water at 30 degrees Celcius flows through a 20 m length of 50 mm plastic (smooth wall) pipe, at a flow rate of 200 L/min.\n",
+    "Water at 30 degrees Celsius flows through a 20 m length of 50 mm plastic (smooth wall) pipe, at a flow rate of 200 L/min.\n",
     "\n",
     "Calculate the Reynolds number and friction factor."
    ]

--- a/docs/Examples/Crane TP 410 Solved Problems/7.10 Piping Systems - Steam.ipynb
+++ b/docs/Examples/Crane TP 410 Solved Problems/7.10 Piping Systems - Steam.ipynb
@@ -13,7 +13,7 @@
     "collapsed": false
    },
    "source": [
-    "40 bar steam, 450 degrees Celcius flows though a 120 m long horizontal 150mm schedule 80 pipe at a rate of\n",
+    "40 bar steam, 450 degrees Celsius flows though a 120 m long horizontal 150mm schedule 80 pipe at a rate of\n",
     "40000 kg/hr. \n",
     "\n",
     "There are three 90 degree weld elbows with rc=1.5, \n",

--- a/docs/Examples/Crane TP 410 Solved Problems/7.11 Flat heating Coils - Water.ipynb
+++ b/docs/Examples/Crane TP 410 Solved Problems/7.11 Flat heating Coils - Water.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Water at 80 degrees Celcius flows through a flat heating coil at a rate of 60 L/min. There are 7 180 degree bends in it. The coil is 8 m long, with 0.5 m of straight length on the inlet and exit. The r/D of the bends is 4. The pipe is schedule 40, 25 mm pipe."
+    "Water at 80 degrees Celsius flows through a flat heating coil at a rate of 60 L/min. There are 7 180 degree bends in it. The coil is 8 m long, with 0.5 m of straight length on the inlet and exit. The r/D of the bends is 4. The pipe is schedule 40, 25 mm pipe."
    ]
   },
   {

--- a/docs/Examples/Crane TP 410 Solved Problems/7.14 Bernoulli's Theorem-Water.ipynb
+++ b/docs/Examples/Crane TP 410 Solved Problems/7.14 Bernoulli's Theorem-Water.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Water at 15 degrees Celcius is flowing through the piping system shown in Crane TP 410M's exmple at 1500 L/min.\n",
+    "Water at 15 degrees Celsius is flowing through the piping system shown in Crane TP 410M's example at 1500 L/min.\n",
     "\n",
     "Calculate the velocity in both 4 and 5 inch sizes; and the pressure drop.\n",
     "\n",

--- a/docs/Examples/Crane TP 410 Solved Problems/7.5 Lift Check Valves.ipynb
+++ b/docs/Examples/Crane TP 410 Solved Problems/7.5 Lift Check Valves.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "A lift check valve of type globe (with a wing-guided disc) is added to a 80 mm Schedule 40 horizontal pipe carying water at a flow rate of 300 L/min.\n",
     "\n",
-    "Calculate the chack valve size, and pressure drop. The disc sould be fully lifted at the specified flow."
+    "Calculate the check valve size, and pressure drop. The disc should be fully lifted at the specified flow."
    ]
   },
   {

--- a/docs/Examples/Crane TP 410 Solved Problems/7.6 Reduced Port Ball Valve.ipynb
+++ b/docs/Examples/Crane TP 410 Solved Problems/7.6 Reduced Port Ball Valve.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Water is discharged at 15 degrees Celcius from a tank with 7 m of head to atmosphere through:\n",
+    "Water is discharged at 15 degrees Celsius from a tank with 7 m of head to atmosphere through:\n",
     "\n",
     "* 60 meters of 80 mm schedule 40 pipe\n",
     "* Six 80 mm standard 90 degree threaded elbows\n",

--- a/docs/Examples/Crane TP 410 Solved Problems/7.7 Laminar flow in Valves, Fittings, and Pipe - System from Example 7.6.ipynb
+++ b/docs/Examples/Crane TP 410 Solved Problems/7.7 Laminar flow in Valves, Fittings, and Pipe - System from Example 7.6.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "SAE oil is discharged at 15 degrees Celcius from a tank with 7 m of head to atmosphere through:\n",
+    "SAE oil is discharged at 15 degrees Celsius from a tank with 7 m of head to atmosphere through:\n",
     "\n",
     "* 60 meters of 80 mm schedule 40 pipe\n",
     "* Six 80 mm standard 90 degree threaded elbows\n",

--- a/docs/Examples/Crane TP 410 Solved Problems/7.8 Laminar flow in Valves, Fittings, and Pipe - SAE oil through a pipe and globe valve.ipynb
+++ b/docs/Examples/Crane TP 410 Solved Problems/7.8 Laminar flow in Valves, Fittings, and Pipe - SAE oil through a pipe and globe valve.ipynb
@@ -13,7 +13,7 @@
     "collapsed": false
    },
    "source": [
-    "S.A.E. 30 Oil at 40 degrees Celcius and a flow rate of 600 barrels/hour flows in a 60 m long 200mm schedule 40 pipe and passes through a 200 mm globe valve, full area seat.\n",
+    "S.A.E. 30 Oil at 40 degrees Celsius and a flow rate of 600 barrels/hour flows in a 60 m long 200mm schedule 40 pipe and passes through a 200 mm globe valve, full area seat.\n",
     "\n",
     "Calculate the pressure drop."
    ]

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -288,7 +288,7 @@ ValueError: Pipe input is larger than max of selected schedule
 Wire gauges
 -----------
 
-The construction of mechanical systems often uses the "gauge" sytems, a variety
+The construction of mechanical systems often uses the "gauge" systems, a variety
 of old imperial conversions between plate or wire thickness and a dimensionless
 number. Conversion from and to the gauge system is done by the :py:func:`~.gauge_from_t` 
 and :py:func:`~.t_from_gauge` functions.

--- a/fluids/atmosphere.py
+++ b/fluids/atmosphere.py
@@ -20,7 +20,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-This module contains models of earth's atmosphere. Models are emperical and
+This module contains models of earth's atmosphere. Models are empirical and
 based on extensive research, primarily by NASA. 
 
 For reporting bugs, adding feature requests, or submitting pull requests, 

--- a/fluids/control_valve.py
+++ b/fluids/control_valve.py
@@ -912,9 +912,9 @@ def convert_flow_coefficient(flow_coefficient, old_scale, new_scale):
         Value of the flow coefficient to be converted, expressed in the 
         original scale.
     old_scale : str
-        String specifing the original scale; one of 'Av', 'Cv', or 'Kv', [-]
+        String specifying the original scale; one of 'Av', 'Cv', or 'Kv', [-]
     new_scale : str
-        String specifing the new scale; one of 'Av', 'Cv', or 'Kv', [-]
+        String specifying the new scale; one of 'Av', 'Cv', or 'Kv', [-]
     
     Returns
     -------
@@ -1188,7 +1188,7 @@ def control_valve_noise_g_2011(m, P1, P2, T1, rho, gamma, MW, Kv,
         Strouhal number at the peak `fp`; between 0.1 and 0.3 typically, [-]
     T2 : float, optional
         Outlet gas temperature; assumed `T1` if not provided (a PH flash 
-        should be uesd to obtain this if possible), [K]
+        should be used to obtain this if possible), [K]
     beta : float, optional
         Valve outlet / expander inlet contraction coefficient, [-]
 

--- a/fluids/design_climate.py
+++ b/fluids/design_climate.py
@@ -342,7 +342,7 @@ class StationDataGSOD(object):
             for i, day in enumerate(data):
                 if day is None:
                     continue
-                # Don't do these comparisions to make it fast
+                # Don't do these comparisons to make it fast
                 if day.DATE.year < older_year or day.DATE.year > newer_year:
                     continue # Ignore out-of-range days as possible
                     
@@ -406,7 +406,7 @@ class StationDataGSOD(object):
             for i, day in enumerate(data):
                 if day is None:
                     continue
-                # Don't do these comparisions to make it fast
+                # Don't do these comparisons to make it fast
                 if day.DATE.year < older_year or day.DATE.year > newer_year:
                     continue # Ignore out-of-range days as possible
                     
@@ -558,10 +558,10 @@ def get_closest_station(latitude, longitude, minumum_recent_data=20140000,
                     'specified near the specified coordinates.')
 
 
-# This should be agressively cached
+# This should be aggressively cached
 def get_station_year_text(WMO, WBAN, year):
     '''Basic method to download data from the GSOD database, given a 
-    station idenfifier and year. 
+    station identifier and year. 
 
     Parameters
     ----------

--- a/fluids/drag.py
+++ b/fluids/drag.py
@@ -95,7 +95,7 @@ def Barati(Re):
 
     Examples
     --------
-    Maching example in [1]_, in a table of calculated values.
+    Matching example in [1]_, in a table of calculated values.
 
     >>> Barati(200.)
     0.7682237950389874
@@ -145,7 +145,7 @@ def Barati_high(Re):
 
     Examples
     --------
-    Maching example in [1]_, in a table of calculated values.
+    Matching example in [1]_, in a table of calculated values.
 
     >>> Barati_high(200.)
     0.7730544082789523
@@ -1201,7 +1201,7 @@ def time_v_terminal_Stokes(D, rhop, rho, mu, V0, tol=1e-14):
         Initial velocity of the particle, [m/s]
     tol : float, optional
         How closely to approach the terminal velocity - the target velocity is
-        the terminal velocity multiplied by 1 (+/-) this, dependeing on if the
+        the terminal velocity multiplied by 1 (+/-) this, depending on if the
         particle is accelerating or decelerating, [-]
 
     Returns

--- a/fluids/geometry.py
+++ b/fluids/geometry.py
@@ -1795,7 +1795,7 @@ class TANK(object):
         Raises an error if the head ratios are not provided.
 
         Calculates initial guesses assuming no heads are present, and then uses
-        fsolve to determine the correct dimentions for the tank.
+        fsolve to determine the correct dimensions for the tank.
 
         Tested, but bugs and limitations are expected here.
         '''

--- a/fluids/jet_pump.py
+++ b/fluids/jet_pump.py
@@ -308,7 +308,7 @@ def liquid_jet_pump(rhop, rhos, Kp=0.0, Ks=0.1, Km=.15, Kd=0.1,
       homogeneously distributed in a continuous liquid phase.
     * Heat transfer between the fluids is negligible - there is no change in
       density due to temperature changes
-    * The change in the solubility of a disolved gas, if there is one, is
+    * The change in the solubility of a dissolved gas, if there is one, is
       negigibly changed by temperature or pressure changes.
 
     The model can be derived from the equations in 

--- a/fluids/nrlmsise00/nrlmsise_00_header.py
+++ b/fluids/nrlmsise00/nrlmsise_00_header.py
@@ -52,8 +52,8 @@ class nrlmsise_flags(object):
  *   Switches: to turn on and off particular variations use these switches.
  *   0 is off, 1 is on, and 2 is main effects off but cross terms on.
  *
- *   Standard values are 0 for switch 0 and 1 for switches 1 to 23. The 
- *   array "switches" needs to be set accordingly by the calling program. 
+ *   Standard values are 0 for switch 0 and 1 for switches 1 to 23. The
+ *   array "switches" needs to be set accordingly by the calling program.
  *   The arrays sw and swc are set internally.
  *
  *   switches[i]:
@@ -100,9 +100,9 @@ class ap_array:
  *   2 : 3 hr AP index for 3 hrs before current time
  *   3 : 3 hr AP index for 6 hrs before current time
  *   4 : 3 hr AP index for 9 hrs before current time
- *   5 : Average of eight 3 hr AP indicies from 12 to 33 hrs 
+ *   5 : Average of eight 3 hr AP indicies from 12 to 33 hrs
  *           prior to current time
- *   6 : Average of eight 3 hr AP indicies from 36 to 57 hrs 
+ *   6 : Average of eight 3 hr AP indicies from 36 to 57 hrs
  *           prior to current time
  """
     def __init__(self):
@@ -112,9 +112,9 @@ class ap_array:
 class nrlmsise_input:
     """
 /*
- *   NOTES ON INPUT VARIABLES: 
+ *   NOTES ON INPUT VARIABLES:
  *      UT, Local Time, and Longitude are used independently in the
- *      model and are not of equal importance for every situation.  
+ *      model and are not of equal importance for every situation.
  *      For the most physically realistic calculation these three
  *      variables should be consistent (lst=sec/3600 + g_long/15).
  *      The Equation of Time departures from the above formula
@@ -154,20 +154,20 @@ class nrlmsise_input:
 
 class nrlmsise_output:
     """
-/* 
+/*
  *   OUTPUT VARIABLES:
  *      d[0] - HE NUMBER DENSITY(CM-3)
  *      d[1] - O NUMBER DENSITY(CM-3)
  *      d[2] - N2 NUMBER DENSITY(CM-3)
  *      d[3] - O2 NUMBER DENSITY(CM-3)
- *      d[4] - AR NUMBER DENSITY(CM-3)                       
+ *      d[4] - AR NUMBER DENSITY(CM-3)
  *      d[5] - TOTAL MASS DENSITY(GM/CM3) [includes d[8] in td7d]
  *      d[6] - H NUMBER DENSITY(CM-3)
  *      d[7] - N NUMBER DENSITY(CM-3)
  *      d[8] - Anomalous oxygen NUMBER DENSITY(CM-3)
  *      t[0] - EXOSPHERIC TEMPERATURE
  *      t[1] - TEMPERATURE AT ALT
- * 
+ *
  *
  *      O, H, and N are set to zero below 72.5 km
  *
@@ -175,7 +175,7 @@ class nrlmsise_output:
  *      altitudes below 120 km. The 120 km gradient is left at global
  *      average value for altitudes below 72 km.
  *
- *      d[5], TOTAL MASS DENSITY, is NOT the same for subroutines GTD7 
+ *      d[5], TOTAL MASS DENSITY, is NOT the same for subroutines GTD7
  *      and GTD7D
  *
  *        SUBROUTINE GTD7 -- d[5] is the sum of the mass densities of the
@@ -196,13 +196,13 @@ class nrlmsise_output:
 #/* ------------------------------------------------------------------- */
 #/* --------------------------- PROTOTYPES ---------------------------- */
 #/* ------------------------------------------------------------------- */
-# No prototypes are used here, these are here for refernce
+# No prototypes are used here, these are here for reference
 '''
 /* GTD7 */
 /*   Neutral Atmosphere Empircial Model from the surface to lower
  *   exosphere.
  */
- 
+
 /* GTD7D */
 /*   This subroutine provides Effective Total Mass Density for output
  *   d[5] which includes contributions from "anomalous oxygen" which can

--- a/fluids/packed_bed.py
+++ b/fluids/packed_bed.py
@@ -902,7 +902,7 @@ def dP_packed_bed(dp, voidage, vs, rho, mu, L=1, Dt=None, sphericity=None,
     to use if none is provided. Returns None if insufficient information is
     provided.
 
-    Prefered correlations are 'Erdim, Akgiray & Demir' when tube
+    Preferred correlations are 'Erdim, Akgiray & Demir' when tube
     diameter is not provided, and 'Harrison, Brunner & Hecker' when tube
     diameter is provided. If you are using a particles in a narrow tube 
     between 2 and 3 particle diameters, expect higher than normal voidages 

--- a/fluids/packed_tower.py
+++ b/fluids/packed_tower.py
@@ -369,7 +369,7 @@ def specific_area_mesh(voidage, d):
 
     Notes
     -----
-    Should be prefered over manufacturer data. Can also be used to show that
+    Should be preferred over manufacturer data. Can also be used to show that
     manufacturer's data is inconsistent with their claimed voidage and wire
     diameter.
 

--- a/fluids/particle_size_distribution.py
+++ b/fluids/particle_size_distribution.py
@@ -855,7 +855,7 @@ def pdf_Rosin_Rammler_basis_integral(d, k, m, n):
     same.
     
     For very high powers of `n` or `m` when the diameter is very low, 
-    execeptions may occur.
+    exceptions may occur.
 
     Examples
     --------

--- a/fluids/safety_valve.py
+++ b/fluids/safety_valve.py
@@ -319,8 +319,8 @@ def API520_SH(T1, P1):
     Notes
     -----
     For P above 20679 kPag, use the critical flow model.
-    Superheat cannot be above 649 degrees Celcius.
-    If T1 is above 149 degrees Celcius, returns 1.
+    Superheat cannot be above 649 degrees Celsius.
+    If T1 is above 149 degrees Celsius, returns 1.
 
     Examples
     --------

--- a/fluids/separator.py
+++ b/fluids/separator.py
@@ -207,7 +207,7 @@ def K_separator_demister_York(P, horizontal=False):
     -------
     K : float
         Sounders Brown Horizontal or vertical `K` factor for two-phase
-        seperator design with a demister, [m/s]
+        separator design with a demister, [m/s]
 
     Notes
     -----
@@ -252,7 +252,7 @@ def K_separator_demister_York(P, horizontal=False):
 def v_Sounders_Brown(K, rhol, rhog):
     r'''Calculates the maximum allowable vapor velocity in a two-phase 
     separator to permit separation between entrained droplets and the gas
-    using an emperical `K` factor, named after Sounders and Brown [1]_.
+    using an empirical `K` factor, named after Sounders and Brown [1]_.
     This is a simplifying expression for terminal velocity and drag on 
     particles.
     

--- a/fluids/two_phase.py
+++ b/fluids/two_phase.py
@@ -2259,7 +2259,7 @@ def two_phase_dP_acceleration(m, D, xi, xo, alpha_i, alpha_o, rho_li, rho_gi,
 def two_phase_dP_dz_acceleration(m, D, x, alpha, rhol, rhog):
     r'''This function handles calculation of two-phase liquid-gas pressure drop
     due to acceleration for flow inside channels. This is a continuous 
-    calculation, providing the differential in pressure per unit lenth and
+    calculation, providing the differential in pressure per unit length and
     should be called as part of an integration routine ([1]_, [2]_).
     
     .. math::

--- a/fluids/two_phase_voidage.py
+++ b/fluids/two_phase_voidage.py
@@ -2416,7 +2416,7 @@ def gas_liquid_viscosity(x, mul, mug, rhol=None, rhog=None, Method=None,
     flag.
     
     **ALL OF THESE METHODS ARE ONLY SUGGESTED DEFINITIONS, POTENTIALLY 
-    USEFUL FOR EMPERICAL WORK ONLY!**
+    USEFUL FOR EMPIRICAL WORK ONLY!**
 
     Parameters
     ----------

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -94,7 +94,7 @@ def test_hwm93():
 
 def test_hwm14():
     # Data in checkhwm14.f90; all checks out.
-    # Disturbance wind model checks are not seperately implemented.
+    # Disturbance wind model checks are not separately implemented.
     try:
     
         # Height profile

--- a/tests/test_control_valve.py
+++ b/tests/test_control_valve.py
@@ -202,7 +202,7 @@ def test_control_valve_size_g():
     assert ans['FR'] is None
     assert ans['Rev']
     
-    # Test a warning is issued and a solution is stil returned when in an unending loop
+    # Test a warning is issued and a solution is still returned when in an unending loop
     # Ends with C ratio converged to 0.907207790871228
     
     

--- a/tests/test_two_phase.py
+++ b/tests/test_two_phase.py
@@ -245,7 +245,7 @@ def test_two_phase_dP():
     dP = two_phase_dP(m=0.6, x=0.1, rhol=915., rhog=2.67, mul=180E-6, mug=14E-6, D=0.05, roughness=0, L=1)
     assert_allclose(dP, 1084.1489922923736)
 
-    # Prefered choice, Kim_Mudawar
+    # Preferred choice, Kim_Mudawar
     dP = two_phase_dP(m=0.6, x=0.1, rhol=915., rhog=2.67, mul=180E-6, mug=14E-6, sigma=0.0487, D=0.05, L=1)
     assert_allclose(dP, 840.4137796786074)
 


### PR DESCRIPTION
Found via `codespell -q 3 -I ../python-fluids-word-whitelist.txt --skip="./fluids/data"` whereby the whitelist consists of:
```
ans
cas
nd
que
te
```