### PR TITLE
Add conda as installation option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,11 @@ If you have an installation of Python with pip, simple install it with:
 
     $ pip install fluids
 
+Alternatively, if you are using `conda <https://conda.io/en/latest/>`_ as your package management, you can simply
+install fluids in your environment from `conda-forge <https://conda-forge.org/>`_ channel with:
+
+    $ conda install -c conda-forge fluids 
+
 To get the git version, run:
 
     $ git clone git://github.com/CalebBell/fluids.git

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,11 @@ If you have an installation of Python with pip, simple install it with:
 
     $ pip install fluids
 
+Alternatively, if you are using `conda <https://conda.io/en/latest/>`_ as your package management, you can simply
+install fluids in your environment from `conda-forge <https://conda-forge.org/>`_ channel with:
+
+    $ conda install -c conda-forge fluids 
+
 To get the git version, run:
 
     $ git clone git://github.com/CalebBell/fluids.git


### PR DESCRIPTION
Hi, @CalebBell.

I added fluids to conda-forge channel. Now, it's possible to install `fluids` from there. I also did it for `thermo` (I will send a PR there). I think it ease the work of some people (like me) whom build conda environments and work on them

I hope you would appreciate it.

PS.: I don't know if there is any missing part which contains install instructions.