### PR TITLE
Enhancements to speed up numba-transform module

### DIFF
--- a/fluids/numba.py
+++ b/fluids/numba.py
@@ -548,8 +548,6 @@ def transform_module(normal, __funcs, replaced, vec=False, blacklist=frozenset([
         del replaced['__file__']
     for mod in new_mods:
         mod.__dict__.update(__funcs)
-        mod.__dict__.update(replaced)
-
     return new_mods
 
 

--- a/fluids/numba.py
+++ b/fluids/numba.py
@@ -467,17 +467,16 @@ def transform_module(normal, __funcs, replaced, vec=False, blacklist=frozenset([
         __funcs['.'.join(mod_split_names[:-1])] = SUBMOD # set fluids.optional.spa fluids.numba.spa
         __funcs['.'.join(mod_split_names[-2:])] = SUBMOD # set 'optional.spa' in the dict too
         try:
-            names = set(SUBMOD.__all__)
+            names = SUBMOD.__all__
         except:
             names = set()
-
-        for mod_obj_name in dir(SUBMOD):
-            obj = getattr(SUBMOD, mod_obj_name)
-            if (isinstance(obj, types.FunctionType)
-                and mod_obj_name != '__getattr__'
-                and not mod_obj_name.startswith('_load')
-                and obj.__module__ == SUBMOD.__name__):
-                names.add(mod_obj_name)
+            for mod_obj_name in dir(SUBMOD):
+                obj = getattr(SUBMOD, mod_obj_name)
+                if (isinstance(obj, types.FunctionType)
+                    and mod_obj_name != '__getattr__'
+                    and not mod_obj_name.startswith('_load')
+                    and obj.__module__ == SUBMOD.__name__):
+                    names.add(mod_obj_name)
 
         # try:
         #     names += SUBMOD.__numba_additional_funcs__

--- a/fluids/numba.py
+++ b/fluids/numba.py
@@ -506,17 +506,15 @@ def transform_module(normal, __funcs, replaced, vec=False, blacklist=frozenset([
                 r_type = type(r) 
                 if r_type in numtypes: 
                     arr = np.array(obj)
+                    if arr.dtype.char != 'O': module_constants_changed_type[arr_name] = arr
                 elif r_type is list and r and type(r[0]) in numtypes:
                     if len(set([len(r) for r in obj])) == 1:
                         # All same size - nice numpy array
                         arr = np.array(obj)
+                        if arr.dtype.char != 'O': module_constants_changed_type[arr_name] = arr
                     else:
                         # Tuple of different size numpy arrays
-                        arr = tuple([np.array(v) for v in obj])
-                else:
-                    continue
-                if arr.dtype.char != 'O':
-                    module_constants_changed_type[arr_name] = arr
+                        module_constants_changed_type[arr_name] = tuple([np.array(v) for v in obj])
             elif obj_type in settypes:
                 module_constants_changed_type[arr_name] = tuple(obj)
             # elif obj_type is dict:

--- a/fluids/numba.py
+++ b/fluids/numba.py
@@ -441,6 +441,8 @@ def transform_module(normal, __funcs, replaced, vec=False, blacklist=frozenset([
         all_submodules = normal.all_submodules()
     except:
         all_submodules = normal.submodules
+    numtypes = {float, int, complex}
+    settypes = {set, frozenset}
     for mod in all_submodules:
         #print(all_submodules, mod)
         SUBMOD_COPY = importlib.util.find_spec(mod.__name__)
@@ -460,29 +462,22 @@ def transform_module(normal, __funcs, replaced, vec=False, blacklist=frozenset([
 
         SUBMOD.__dict__.update(replaced)
         new_mods.append(SUBMOD)
-        __funcs[mod.__name__.split('.')[-1]] = SUBMOD # fluids.numba.optional.spa
-        __funcs['.'.join(mod.__name__.split('.')[:-1])] = SUBMOD # set fluids.optional.spa fluids.numba.spa
-        __funcs['.'.join(mod.__name__.split('.')[-2:])] = SUBMOD # set 'optional.spa' in the dict too
+        mod_split_names = mod.__name__.split('.')
+        __funcs[mod_split_names[-1]] = SUBMOD # fluids.numba.optional.spa
+        __funcs['.'.join(mod_split_names[:-1])] = SUBMOD # set fluids.optional.spa fluids.numba.spa
+        __funcs['.'.join(mod_split_names[-2:])] = SUBMOD # set 'optional.spa' in the dict too
         try:
-            names = list(SUBMOD.__all__)
+            names = set(SUBMOD.__all__)
         except:
-            names = []
+            names = set()
 
-        allow_fail_names = set([])
         for mod_obj_name in dir(SUBMOD):
             obj = getattr(SUBMOD, mod_obj_name)
-            if isinstance(obj, types.FunctionType):
-                if mod_obj_name in ('__getattr__',):
-                    # Names which cannot be converted
-                    continue
-                if mod_obj_name.startswith('_load'):
-                    continue
-
-                if mod_obj_name not in names:
-                    # Check if the function is local to the module
-                    if obj.__module__ == SUBMOD.__name__:
-                        names.append(mod_obj_name)
-                        allow_fail_names.add(mod_obj_name)
+            if (isinstance(obj, types.FunctionType)
+                and mod_obj_name != '__getattr__'
+                and not mod_obj_name.startswith('_load')
+                and obj.__module__ == SUBMOD.__name__):
+                names.add(mod_obj_name)
 
         # try:
         #     names += SUBMOD.__numba_additional_funcs__
@@ -493,7 +488,6 @@ def transform_module(normal, __funcs, replaced, vec=False, blacklist=frozenset([
         for name in names:
             obj = getattr(SUBMOD, name)
             if isinstance(obj, types.FunctionType):
-                nopython = name not in skip
                 if name not in total_skip and name not in blacklist:
                     try:
                         obj = conv_fun(cache=(caching and name not in cache_blacklist), **extra_args)(obj)
@@ -507,31 +501,37 @@ def transform_module(normal, __funcs, replaced, vec=False, blacklist=frozenset([
             __funcs[name] = obj
 
         module_constants_changed_type = {}
-        for arr_name in SUBMOD.__dict__.keys():
-            if arr_name not in no_conv_data_names:
-                obj = getattr(SUBMOD, arr_name)
-                obj_type = type(obj)
-                if obj_type is list and len(obj) and type(obj[0]) in (float, int, complex):
-                    module_constants_changed_type[arr_name] = np.array(obj)
-                elif (obj_type is list and len(obj) and all([
-                        (type(r) is list and len(r) and type(r[0]) in (float, int, complex)) for r in obj])):
+        for arr_name in SUBMOD.__dict__:
+            if arr_name in no_conv_data_names: continue
+            obj = getattr(SUBMOD, arr_name)
+            obj_type = type(obj)
+            if obj_type is list and obj:
+                # Assume all elements have the same general type
+                r = obj[0]
+                r_type = type(r) 
+                if r_type in numtypes: 
+                    arr = np.array(obj)
+                elif r_type is list and r and type(r[0]) in numtypes:
                     if len(set([len(r) for r in obj])) == 1:
                         # All same size - nice numpy array
-                        module_constants_changed_type[arr_name] = np.array(obj)
+                        arr = np.array(obj)
                     else:
                         # Tuple of different size numpy arrays
-                        module_constants_changed_type[arr_name] = tuple(np.array(v) for v in obj)
-                elif obj_type in (set, frozenset):
-                    module_constants_changed_type[arr_name] = tuple(obj)
-                elif obj_type is dict:
+                        arr = tuple([np.array(v) for v in obj])
+                else:
                     continue
-                    try:
-                        print('starting', arr_name)
-                        infer_dictionary_types(obj)
-                        module_constants_changed_type[arr_name] = numba_dict(obj)
-                    except:
-                        print(arr_name, 'failed')
-                        pass
+                if arr.dtype.char != 'O':
+                    module_constants_changed_type[arr_name] = arr
+            elif obj_type in settypes:
+                module_constants_changed_type[arr_name] = tuple(obj)
+            # elif obj_type is dict:
+            #     try:
+            #         print('starting', arr_name)
+            #         infer_dictionary_types(obj)
+            #         module_constants_changed_type[arr_name] = numba_dict(obj)
+            #     except:
+            #         print(arr_name, 'failed')
+            #         pass
 
         SUBMOD.__dict__.update(module_constants_changed_type)
         __funcs.update(module_constants_changed_type)
@@ -548,7 +548,6 @@ def transform_module(normal, __funcs, replaced, vec=False, blacklist=frozenset([
                     glob = t.__globals__
                 glob.update(SUBMOD.__dict__)
                 #glob.update(to_do)
-                glob.update(replaced)
 
     # Do our best to allow functions to be found
     if '__file__' in __funcs:

--- a/fluids/numba.py
+++ b/fluids/numba.py
@@ -466,17 +466,18 @@ def transform_module(normal, __funcs, replaced, vec=False, blacklist=frozenset([
         __funcs[mod_split_names[-1]] = SUBMOD # fluids.numba.optional.spa
         __funcs['.'.join(mod_split_names[:-1])] = SUBMOD # set fluids.optional.spa fluids.numba.spa
         __funcs['.'.join(mod_split_names[-2:])] = SUBMOD # set 'optional.spa' in the dict too
+       
         try:
-            names = SUBMOD.__all__
+            names = set(SUBMOD.__all__)
         except:
             names = set()
-            for mod_obj_name in dir(SUBMOD):
-                obj = getattr(SUBMOD, mod_obj_name)
-                if (isinstance(obj, types.FunctionType)
-                    and mod_obj_name != '__getattr__'
-                    and not mod_obj_name.startswith('_load')
-                    and obj.__module__ == SUBMOD.__name__):
-                    names.add(mod_obj_name)
+        for mod_obj_name in dir(SUBMOD):
+            obj = getattr(SUBMOD, mod_obj_name)
+            if (isinstance(obj, types.FunctionType)
+                and mod_obj_name != '__getattr__'
+                and not mod_obj_name.startswith('_load')
+                and obj.__module__ == SUBMOD.__name__):
+                names.add(mod_obj_name)
 
         # try:
         #     names += SUBMOD.__numba_additional_funcs__
@@ -488,13 +489,7 @@ def transform_module(normal, __funcs, replaced, vec=False, blacklist=frozenset([
             obj = getattr(SUBMOD, name)
             if isinstance(obj, types.FunctionType):
                 if name not in total_skip and name not in blacklist:
-                    try:
-                        obj = conv_fun(cache=(caching and name not in cache_blacklist), **extra_args)(obj)
-                    except Exception as e:
-                        if name in mod_obj_name:
-                            continue
-                        else:
-                            raise e
+                    obj = conv_fun(cache=(caching and name not in cache_blacklist), **extra_args)(obj)
                 SUBMOD.__dict__[name] = obj
                 new_objs.append(obj)
             __funcs[name] = obj


### PR DESCRIPTION
Hi Caleb,

I took a detailed look into the `transform_module` function in `fluids.numba` and found some straightforward things I could enhance, including preventing exceptions, reusing more variables, and removing some redundant code. There might be more that could be done, but it's probably not so easy. 

I haven't measured the loading time yet, but it should be significant. 

All tests passed. I also tested it with `chemicals` and all tests passed as well.

Thanks!