### PR TITLE
Make the documentation year reproducible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,8 +77,13 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Fluids'
+import os
+import time
 import datetime
-copyright = u'2016 - %s, Caleb Bell <Caleb.Andrew.Bell@gmail.com>' %datetime.datetime.now().year
+build_date = datetime.datetime.utcfromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+)
+copyright = u'2016 - %s, Caleb Bell <Caleb.Andrew.Bell@gmail.com>' % build_date.year
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort I noticed that fluids could not be built reproducibly.

This is due to the documentation automatically including the current year in a copyright footer, which means that the build will change depending on when you build.

This pull request uses [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) to make this "build date" configurable/pluggable.

I originally filed this in Debian as bug number [#1004391](https://bugs.debian.org/1004391).